### PR TITLE
AuthInfoの取扱を変更、LoggingSessionにIDの概念追加

### DIFF
--- a/calico-core/src/main/java/jp/co/freemind/calico/core/auth/AuthorizationRule.java
+++ b/calico-core/src/main/java/jp/co/freemind/calico/core/auth/AuthorizationRule.java
@@ -10,12 +10,8 @@ public interface AuthorizationRule {
   void apply(Context context, Class<? extends Endpoint<?, ?>> endpointClass, Object input) throws AuthorizationException;
 
   default boolean isAuthorizedWith(Context context, Authority... authorities) {
-    return context.getAuthInfo()
-      .map(AuthInfo::getAuthorities)
-      .flatMap(rs -> Arrays.stream(authorities)
-        .filter(rs::contains)
-        .findFirst())
-      .isPresent();
+    return Arrays.stream(authorities)
+        .anyMatch(context.getAuthInfo().getAuthorities()::contains);
   }
 
 }

--- a/calico-core/src/main/java/jp/co/freemind/calico/core/log/LoggingSession.java
+++ b/calico-core/src/main/java/jp/co/freemind/calico/core/log/LoggingSession.java
@@ -1,6 +1,7 @@
 package jp.co.freemind.calico.core.log;
 
-public interface LoggingSession {
+public interface LoggingSession<ID> {
   void finish(int statusCode);
-  void finish(Throwable t);
+  void error(Throwable t);
+  ID getId();
 }

--- a/calico-core/src/main/java/jp/co/freemind/calico/core/zone/Context.java
+++ b/calico-core/src/main/java/jp/co/freemind/calico/core/zone/Context.java
@@ -6,11 +6,11 @@ import java.util.AbstractMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import jp.co.freemind.calico.core.auth.AuthInfo;
 
@@ -32,6 +32,7 @@ public class Context {
 
   private Context(Spec spec) {
     Objects.requireNonNull(spec.path);
+    Objects.requireNonNull(spec.authInfo);
     Objects.requireNonNull(spec.processDateTime);
     Objects.requireNonNull(spec.remoteAddress);
     Objects.requireNonNull(spec.metaInfo);
@@ -49,8 +50,9 @@ public class Context {
   }
 
   @SuppressWarnings("unchecked")
-  public <T extends AuthInfo> Optional<T> getAuthInfo() {
-    return Optional.ofNullable((T) authInfo);
+  @Nonnull
+  public <T extends AuthInfo> T getAuthInfo() {
+    return (T) authInfo;
   }
 
   public LocalDateTime getProcessDateTime() {
@@ -96,16 +98,16 @@ public class Context {
     public Spec path(String path) {
       return new Spec(path, authInfo, processDateTime, remoteAddress, metaInfo);
     }
-    public Spec authInfo(AuthInfo authInfo) {
+    public Spec authInfo(@Nonnull AuthInfo authInfo) {
       return new Spec(path, authInfo, processDateTime, remoteAddress, metaInfo);
     }
-    public Spec processDateTime(LocalDateTime processDateTime) {
+    public Spec processDateTime(@Nonnull LocalDateTime processDateTime) {
       return new Spec(path, authInfo, processDateTime, remoteAddress, metaInfo);
     }
-    public Spec remoteAddress(String remoteAddress) {
+    public Spec remoteAddress(@Nonnull String remoteAddress) {
       return new Spec(path, authInfo, processDateTime, remoteAddress, metaInfo);
     }
-    public Spec entry(String key, String value) {
+    public Spec entry(@Nonnull String key, @Nullable String value) {
       Set<Map.Entry<String, String>> set = new LinkedHashSet<>(metaInfo);
       set.add(new AbstractMap.SimpleEntry<>(key, value));
       return new Spec(path, authInfo, processDateTime, remoteAddress, set);

--- a/calico-servlet/src/main/java/jp/co/freemind/calico/servlet/RequestSession.java
+++ b/calico-servlet/src/main/java/jp/co/freemind/calico/servlet/RequestSession.java
@@ -44,7 +44,7 @@ public class RequestSession {
             .scope(TransactionScoped.class)
             .provide(Keys.LOGGING_SESSION, loggingSession)
             .onError(e -> {
-              loggingSession.finish(e);
+              loggingSession.error(e);
               renderError(context, param, e);
               throw e;
             })

--- a/calico-servlet/src/main/java/jp/co/freemind/calico/servlet/interceptor/CsrfInterceptor.java
+++ b/calico-servlet/src/main/java/jp/co/freemind/calico/servlet/interceptor/CsrfInterceptor.java
@@ -1,7 +1,6 @@
 package jp.co.freemind.calico.servlet.interceptor;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -17,25 +16,17 @@ import jp.co.freemind.calico.servlet.util.CookieUtil;
 
 public class CsrfInterceptor implements EndpointInterceptor {
   private final Message insecureMessage;
-  private final boolean permitWhenAuthInfoIsNull;
 
   public CsrfInterceptor(Message insecureMessage) {
-    this(insecureMessage, false);
-  }
-  public CsrfInterceptor(Message insecureMessage, boolean permitWhenAuthInfoIsNull) {
     this.insecureMessage = insecureMessage;
-    this.permitWhenAuthInfoIsNull = permitWhenAuthInfoIsNull;
   }
 
   @Override
   public Object invoke(EndpointInvocation invocation) throws Throwable {
     HttpServletRequest req = Zone.getCurrent().getInstance(Keys.SERVLET_REQUEST);
-    Optional<AuthInfo> authInfo = Zone.getContext().getAuthInfo();
-    if (authInfo.map(ai -> false).orElse(permitWhenAuthInfoIsNull)) {
-      return invocation.proceed();
-    }
+    AuthInfo authInfo = Zone.getContext().getAuthInfo();
 
-    if (authInfo.map(AuthInfo::isUsedBySystem).orElse(false)) {
+    if (authInfo.isUsedBySystem()) {
       return invocation.proceed();
     }
 

--- a/calico-servlet/src/main/java/jp/co/freemind/calico/servlet/renderer/DefaultRenderer.java
+++ b/calico-servlet/src/main/java/jp/co/freemind/calico/servlet/renderer/DefaultRenderer.java
@@ -9,7 +9,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jp.co.freemind.calico.core.auth.AuthInfo;
+import jp.co.freemind.calico.core.auth.AuthToken;
 import jp.co.freemind.calico.core.endpoint.result.Result;
 import jp.co.freemind.calico.core.endpoint.result.ResultType;
 import jp.co.freemind.calico.core.zone.Context;
@@ -31,12 +31,9 @@ public class DefaultRenderer implements Renderer<Result> {
     if (o == null) return;
     ServletContext servletContext = conf.getServletContext();
 
-    o.getContext().getAuthInfo()
-      .map(AuthInfo::getAuthToken)
-      .ifPresent(token -> {
-        CookieUtil.setSessionToken(servletContext, res, token);
-        CookieUtil.setCsrfToken(servletContext, res, token);
-      });
+    AuthToken token = o.getContext().getAuthInfo().getAuthToken();
+    CookieUtil.setSessionToken(servletContext, res, token);
+    CookieUtil.setCsrfToken(servletContext, res, token);
   }
 
   @Override

--- a/service/src/main/java/calicosample/core/auth/BaseAuthZRule.java
+++ b/service/src/main/java/calicosample/core/auth/BaseAuthZRule.java
@@ -8,7 +8,6 @@ import java.util.stream.Stream;
 
 import calicosample.Messages;
 import calicosample.extenum.CalicoSampleAuthority;
-import jp.co.freemind.calico.core.auth.AuthInfo;
 import jp.co.freemind.calico.core.auth.AuthorizationRule;
 import jp.co.freemind.calico.core.endpoint.Endpoint;
 import jp.co.freemind.calico.core.exception.AuthorizationException;
@@ -42,6 +41,6 @@ public class BaseAuthZRule implements AuthorizationRule {
   }
 
   private boolean isAuthenticated(Context context) {
-    return context.getAuthInfo().map(AuthInfo::isAuthenticated).orElse(true);
+    return context.getAuthInfo().isAuthenticated();
   }
 }

--- a/service/src/main/java/calicosample/endpoint/auth/KeepEndpoint.java
+++ b/service/src/main/java/calicosample/endpoint/auth/KeepEndpoint.java
@@ -14,7 +14,7 @@ public class KeepEndpoint implements Endpoint<EmptyInput, Result> {
 
   @Override
   public Result execute(EmptyInput input) {
-    CalicoSampleAuthInfo authInfo = authService.keep(context.<CalicoSampleAuthInfo>getAuthInfo().orElse(null));
+    CalicoSampleAuthInfo authInfo = authService.keep(context.getAuthInfo());
     return new Result(context.extend(s -> s.authInfo(authInfo)), authInfo);
   }
 }

--- a/service/src/main/java/calicosample/entity/CalicoSampleEntity.java
+++ b/service/src/main/java/calicosample/entity/CalicoSampleEntity.java
@@ -3,7 +3,6 @@ package calicosample.entity;
 import java.time.LocalDateTime;
 
 import calicosample.core.doma.InjectConfig;
-import jp.co.freemind.calico.core.auth.AuthInfo;
 import jp.co.freemind.calico.core.zone.Zone;
 import lombok.Getter;
 import lombok.Setter;
@@ -35,9 +34,8 @@ public abstract class CalicoSampleEntity {
     }
 
     private String getLoginId() {
-      return Zone.getContext().getAuthInfo()
-        .map(AuthInfo::getLoginId)
-        .orElse("");
+      String id = Zone.getContext().getAuthInfo().getLoginId();
+      return id != null ? id : "";
     }
   }
 }

--- a/service/src/main/java/calicosample/service/system/LoggingService.java
+++ b/service/src/main/java/calicosample/service/system/LoggingService.java
@@ -2,7 +2,6 @@ package calicosample.service.system;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.inject.Named;
@@ -52,16 +51,16 @@ public class LoggingService {
   public int insert(JsLogForm form) {
     if (!isLoggable()) return 0;
     Context context = Zone.getContext();
-    Optional<AuthInfo> authInfo = context.getAuthInfo();
-    Optional<AuthToken> authToken = context.getAuthInfo().map(AuthInfo::getAuthToken);
+    AuthInfo authInfo = context.getAuthInfo();
+    AuthToken authToken = authInfo.getAuthToken();
 
     JsLog log = new JsLog();
     log.setLocation(form.getLocation());
     log.setUserAgent(form.getUserAgent());
     log.setException(form.getException());
-    log.setLoginId(authInfo.map(AuthInfo::getLoginId).orElse(null));
-    log.setRemoteAddr(authToken.map(AuthToken::getRemoteAddress).orElse(null));
-    log.setSessionId(authToken.map(AuthToken::getValue).orElse(null));
+    log.setLoginId(authInfo.getLoginId());
+    log.setRemoteAddr(authToken.getRemoteAddress());
+    log.setSessionId(authToken.getValue());
     log.setException(form.getException());
     return dao.insert(log);
   }

--- a/web/src/main/java/calicosample/log/AccessLoggingSession.java
+++ b/web/src/main/java/calicosample/log/AccessLoggingSession.java
@@ -30,7 +30,7 @@ import jp.co.freemind.calico.core.log.LoggingSession;
 import jp.co.freemind.calico.core.util.StreamUtil;
 import jp.co.freemind.calico.servlet.util.NetworkUtil;
 
-public class AccessLoggingSession implements LoggingSession {
+public class AccessLoggingSession implements LoggingSession<Long> {
   private final LoggingDao loggingDao;
   private final LogDbSetting setting;
   private final AccessStartLog startLog;
@@ -78,16 +78,19 @@ public class AccessLoggingSession implements LoggingSession {
   }
 
   @Override
-  public void finish(Throwable t) {
-    if (finished) return;
-    finished = true;
-
+  public void error(Throwable t) {
     if (setting.getJdbcUrl() == null) return;
 
     ErrorLog errorLog = new ErrorLog();
     errorLog.setStartLog(this.startLog);
     errorLog.setException(Throwables.getStackTraceAsString(t));
     errorLog.setHeaders(collectAllHeaders(this.request));
+  }
+
+  @Override
+  public Long getId() {
+    if (this.startLog == null) return null;
+    return this.startLog.getId();
   }
 
   private static Pattern REFERER = Pattern.compile("^(?:https?://[^/]+)(/[^?]*)?$");


### PR DESCRIPTION
`Context.getAuthInfo()`で返す値をNonnullにしました。
これにともない、AuthInfoはヌルオブジェクトを実装しなければならなくなりました。

あと、LoggingSessionのIDを取得できるようにしました。