### PR TITLE
Endpoint解決時にパッケージにアンダースコアが含まれるのをなくす

### DIFF
--- a/calico-core/src/main/java/jp/co/freemind/calico/core/endpoint/EndpointResolver.java
+++ b/calico-core/src/main/java/jp/co/freemind/calico/core/endpoint/EndpointResolver.java
@@ -63,7 +63,7 @@ public class EndpointResolver {
       for (int i = 1, len = fragments.length - 1; i < len; i++) {
         String fragment = fragments[i];
         if (!FRAGMENT.matcher(fragment).matches()) return Optional.empty();
-        builder.append('.').append(fragment);
+        builder.append('.').append(fragment.replace("_", ""));
       }
       String fragment = fragments[fragments.length - 1];
       if (!FRAGMENT.matcher(fragment).matches()) return Optional.empty();


### PR DESCRIPTION
現在は `api/urgent_notice/get_all` というURLにリクエストを投げると、`root.urgent_notice.GetAllEndpoint` に解決される。
ところが空のコード規約だと package 名にアンダースコアは許容されていない。
しかし URL はわかりやすいようにアンダースコアで区切りたい。

OSSとしては将来的には外部から設定できるべきかもしれない。