### PR TITLE
認証済みでない場合、タイムアウト判定を行わない

### DIFF
--- a/calico-servlet/src/main/java/jp/co/freemind/calico/servlet/interceptor/TimeoutInterceptor.java
+++ b/calico-servlet/src/main/java/jp/co/freemind/calico/servlet/interceptor/TimeoutInterceptor.java
@@ -26,6 +26,10 @@ public class TimeoutInterceptor implements EndpointInterceptor {
 
   @Override
   public Object invoke(EndpointInvocation invocation) throws Throwable {
+    if (!Zone.getContext().getAuthInfo().isAuthenticated()) {
+      return invocation.proceed();
+    }
+
     long timeout = Zone.getCurrent().getInstance(SessionSetting.class).timeoutSecond();
 
     if (timeout > 0) {


### PR DESCRIPTION
認証済みではない場合、タイムアウトかどうかの判定は必要ないのではないでしょうか？
